### PR TITLE
removing Duplicated Plates recipes

### DIFF
--- a/kubejs/server_scripts/standardrecipes.js
+++ b/kubejs/server_scripts/standardrecipes.js
@@ -823,14 +823,6 @@ event.shapeless(
   Item.of('kubejs:nugget_quartz', 9), // output
   ['minecraft:quartz'] //input
 )
-
-
-event.shaped('kubejs:plate_diamond', [
-  'BA',
-  'A '
-  ], {
-  A: Item.of('#forge:gemingot/diamond' ),
-  B: 'immersiveengineering:hammer'})
   
   event.recipes.thermal.press('kubejs:plate_endsteel', '#forge:gemingot/endsteel')
   event.recipes.thermal.press('kubejs:plate_darksteel', '#forge:gemingot/darksteel')

--- a/kubejs/server_scripts/standardrecipes.js
+++ b/kubejs/server_scripts/standardrecipes.js
@@ -831,24 +831,6 @@ event.shaped('kubejs:plate_diamond', [
   ], {
   A: Item.of('#forge:gemingot/diamond' ),
   B: 'immersiveengineering:hammer'})
-
-  var materials43 = [
-    "endsteel",
-    "darksteel",
-    "emerald",
-    "lapis",
-    "quartz"
-  ];
-  
-  materials43.forEach(function(material) {
-    event.shaped('kubejs:plate_' + material, [
-      'BA',
-      'A '
-    ], {
-      A: Item.of('#forge:gemingot/' + material),
-      B: 'immersiveengineering:hammer'
-    })
-  });
   
   event.recipes.thermal.press('kubejs:plate_endsteel', '#forge:gemingot/endsteel')
   event.recipes.thermal.press('kubejs:plate_darksteel', '#forge:gemingot/darksteel')


### PR DESCRIPTION
 - removing **materials43** because stacia plates are already defined in **materials42** the exact same way.


- removed the standalone recipe for Diamond Plate because it was already defined in **materials40**